### PR TITLE
Fix two bugs.

### DIFF
--- a/mic/conf.py
+++ b/mic/conf.py
@@ -157,7 +157,7 @@ class ConfigMgr(object):
                 msger.info("\nUse detected arch %s." % target_archlist[0])
             else:
                 raise errors.ConfigError("Please specify a valid arch, "
-                                         "your choise can be: " % ', '.join(target_archlist))
+                                         "your choise can be: %s" % ', '.join(target_archlist))
 
         kickstart.resolve_groups(self.create, self.create['repomd'])
 

--- a/mic/conf.py
+++ b/mic/conf.py
@@ -146,18 +146,18 @@ class ConfigMgr(object):
         self.create['repomd'] = misc.get_metadata_from_repos(ksrepos, self.create['cachedir'])
         msger.raw(" DONE")
 
-        target_archlist = misc.get_arch(self.create['repomd'])
+        target_archlist, archlist = misc.get_arch(self.create['repomd'])
         if self.create['arch']:
-            if self.create['arch'] not in target_archlist:
+            if self.create['arch'] not in archlist:
                 raise errors.ConfigError("Invalid arch %s for repository. Valid arches: %s"\
-                                         % (self.create['arch'], ', '.join(target_archlist)))
+                                         % (self.create['arch'], ', '.join(archlist)))
         else:
             if len(target_archlist) == 1:
                 self.create['arch'] = str(target_archlist[0])
                 msger.info("\nUse detected arch %s." % target_archlist[0])
             else:
-                raise errors.ConfigError("Please specify a valid arch, "
-                                         "your choise can be: %s" % ', '.join(target_archlist))
+                raise errors.ConfigError("Please specify a valid arch, "\
+                                         "your choise can be: %s" % ', '.join(archlist))
 
         kickstart.resolve_groups(self.create, self.create['repomd'])
 

--- a/mic/utils/misc.py
+++ b/mic/utils/misc.py
@@ -373,7 +373,7 @@ def get_arch(repometadata):
         if need_append:
              uniq_arch.append(archlist[i])
 
-    return uniq_arch
+    return uniq_arch, archlist
 
 def get_package(pkg, repometadata, arch = None):
     ver = ""


### PR DESCRIPTION
 Bug description:

```
    Architecture isn't read from the .ks file as in mic2? But still trace shouldn't be shown.
 #http://pastie.org/2984703
Mic is unable to find the proper architecture in this case from the repo
 #http://pastie.org/2984777
```
