### PR TITLE
Implemented repository option --ssl_verify

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -160,7 +160,8 @@ The blow is the content of one sample file: ::
   
   ; proxy = http://proxy.yourcompany.com:8080/
   ; no_proxy = localhost,127.0.0.0/8,.yourcompany.com
-  
+  ; ssl_verify = no
+
   [convert]
   ; settings for convert subcommand
   

--- a/distfiles/mic.conf
+++ b/distfiles/mic.conf
@@ -10,6 +10,7 @@ pkgmgr = zypp
 
 ; proxy = http://proxy.yourcompany.com:8080/
 ; no_proxy = localhost,127.0.0.0/8,.yourcompany.com
+; ssl_verify = no
 
 [convert]
 ; settings for convert subcommand

--- a/mic/imager/baseimager.py
+++ b/mic/imager/baseimager.py
@@ -829,9 +829,12 @@ class BaseImageCreator(object):
         pkg_manager.setup(yum_conf, self._instroot)
 
         for repo in kickstart.get_repos(self.ks, repo_urls):
-            (name, baseurl, mirrorlist, inc, exc, proxy, proxy_username, proxy_password, debuginfo, source, gpgkey, disable) = repo
+            (name, baseurl, mirrorlist, inc, exc,
+             proxy, proxy_username, proxy_password, debuginfo,
+             source, gpgkey, disable, ssl_verify) = repo
 
-            yr = pkg_manager.addRepository(name, baseurl, mirrorlist, proxy, proxy_username, proxy_password, inc, exc)
+            yr = pkg_manager.addRepository(name, baseurl, mirrorlist, proxy,
+                        proxy_username, proxy_password, inc, exc, ssl_verify)
 
         if kickstart.exclude_docs(self.ks):
             rpm.addMacro("_excludedocs", "1")

--- a/mic/kickstart/__init__.py
+++ b/mic/kickstart/__init__.py
@@ -685,8 +685,13 @@ def get_repos(ks, repo_urls = {}):
             gpgkey = repo.gpgkey
         if hasattr(repo, "disable"):
             disable = repo.disable
+        ssl_verify = True
+        if hasattr(repo, "ssl_verify"):
+            ssl_verify = repo.ssl_verify == "yes"
 
-        repos[repo.name] = (repo.name, baseurl, mirrorlist, inc, exc, proxy, proxy_username, proxy_password, debuginfo, source, gpgkey, disable)
+        repos[repo.name] = (repo.name, baseurl, mirrorlist, inc, exc,
+                            proxy, proxy_username, proxy_password, debuginfo,
+                            source, gpgkey, disable, ssl_verify)
 
     return repos.values()
 

--- a/mic/kickstart/custom_commands/moblinrepo.py
+++ b/mic/kickstart/custom_commands/moblinrepo.py
@@ -25,7 +25,8 @@ from pykickstart.commands.repo import *
 class Moblin_RepoData(F8_RepoData):
     def __init__(self, baseurl="", mirrorlist="", name="", priority=None,
                  includepkgs=[], excludepkgs=[], save=False, proxy=None,
-                 proxy_username=None, proxy_password=None, debuginfo=False, source=False, gpgkey=None, disable=False):
+                 proxy_username=None, proxy_password=None, debuginfo=False,
+                 source=False, gpgkey=None, disable=False, ssl_verify="yes"):
         F8_RepoData.__init__(self, baseurl=baseurl, mirrorlist=mirrorlist,
                              name=name,  includepkgs=includepkgs,
                              excludepkgs=excludepkgs)
@@ -37,6 +38,7 @@ class Moblin_RepoData(F8_RepoData):
         self.disable = disable
         self.source = source
         self.gpgkey = gpgkey
+        self.ssl_verify = ssl_verify.lower()
 
     def _getArgsAsStr(self):
         retval = F8_RepoData._getArgsAsStr(self)
@@ -57,6 +59,8 @@ class Moblin_RepoData(F8_RepoData):
             retval += " --gpgkey=%s" % self.gpgkey
         if self.disable:
             retval += " --disable"
+        if self.ssl_verify:
+            retval += " --ssl_verify=%s" % self.ssl_verify
 
         return retval
 
@@ -93,4 +97,6 @@ class Moblin_Repo(F8_Repo):
                       default=False)
         op.add_option("--gpgkey", type="string", action="store", dest="gpgkey",
                       default=None, nargs=1)
+        op.add_option("--ssl_verify", type="string", action="store", dest="ssl_verify",
+                      default="yes")
         return op

--- a/mic/utils/misc.py
+++ b/mic/utils/misc.py
@@ -225,6 +225,8 @@ def get_repostrs_from_ks(ks):
             repostr += ",source:"
         if  hasattr(repodata, "gpgkey") and repodata.gpgkey:
             repostr += ",gpgkey:" + repodata.gpgkey
+        if hasattr(repodata, "ssl_verify") and repodata.ssl_verify:
+            repostr += ",ssl_verify:" + repodata.ssl_verify
         kickstart_repos.append(repostr[1:])
     return kickstart_repos
 

--- a/plugins/backend/zypppkgmgr.py
+++ b/plugins/backend/zypppkgmgr.py
@@ -249,7 +249,9 @@ class Zypp(BackendPlugin):
         else:
             raise CreatorError("Unable to find pattern: %s" % (grp,))
 
-    def addRepository(self, name, url = None, mirrorlist = None, proxy = None, proxy_username = None, proxy_password = None, inc = None, exc = None):
+    def addRepository(self, name, url = None, mirrorlist = None, proxy = None,
+                      proxy_username = None, proxy_password = None,
+                      inc = None, exc = None, ssl_verify = True):
         if not self.repo_manager:
             self.__initialize_repo_manager()
 
@@ -259,6 +261,7 @@ class Zypp(BackendPlugin):
         repo.proxy = proxy
         repo.proxy_username = proxy_username
         repo.proxy_password = proxy_password
+        repo.ssl_verify = ssl_verify
         repo.baseurl.append(url)
         if inc:
             for pkg in inc:
@@ -287,6 +290,8 @@ class Zypp(BackendPlugin):
             repo_info.setAutorefresh(repo.autorefresh)
             repo_info.setKeepPackages(repo.keeppackages)
             baseurl = zypp.Url(repo.baseurl[0])
+            if not ssl_verify:
+                baseurl.setQueryParam("ssl_verify", "no")
             if proxy:
                 (scheme, host, path, parm, query, frag) = urlparse.urlparse(proxy)
                 proxyinfo = host.split(":")

--- a/tests/mic_cases/base/test.conf
+++ b/tests/mic_cases/base/test.conf
@@ -11,6 +11,7 @@ arch = i586
 
 ; proxy = http://proxy.yourcompany.com:8080/
 ; no_proxy = localhost,127.0.0.0/8,.yourcompany.com
+; ssl_verify = no
 
 [convert]
 ; settings for convert subcommand


### PR DESCRIPTION
This is implementation of --ssl_verify repository option, which allows users to skip ssl verification checks for the repos with broken ssl certificates.
